### PR TITLE
Replaced Invalid Cmdlets

### DIFF
--- a/E2/2. Per Image SKU.ps1
+++ b/E2/2. Per Image SKU.ps1
@@ -39,17 +39,16 @@ $SrcObjParams = @{
     Sku                     = $info.Sku
     Version                 = 'latest'
 }
-$srcPlatform = New-AzImageBuilderSourceObject @SrcObjParams
+$srcPlatform = New-AzImageBuilderTemplateSourceObject -PlatformImageSource @SrcObjParams
 
 #Create an Azure image builder customization object.
 
 $ImgCustomParams = @{
-    PowerShellCustomizer = $true
-    CustomizerName       = 'settingUpMgmtAgtPath'
+    Name       = 'settingUpMgmtAgtPath'
     RunElevated          = $false
     Inline               = @("mkdir c:\\buildActions", "echo Azure-Image-Builder-Was-Here  > c:\\buildActions\\buildActionsOutput.txt")
 }
-$Customizer = New-AzImageBuilderCustomizerObject @ImgCustomParams
+$Customizer = New-AzImageBuilderTemplateCustomizerObject -PowerShellCustomizer @ImgCustomParams
 
 #Create an Azure image builder distributor object.
 
@@ -61,7 +60,7 @@ $disObjParams = @{
     RunOutputName          = $runOutputName
     ExcludeFromLatest      = $false
 }
-$disSharedImg = New-AzImageBuilderDistributorObject @disObjParams
+$disSharedImg = New-AzImageBuilderTemplateDistributorObject @disObjParams
 
 #Create an Azure image builder template.
 


### PR DESCRIPTION
Updated cmdlets: New-AzImageBuilderTemplateSourceObject, New-AzImageBuilderTemplateCustomizerObject and New-AzImageBuilderTemplateDistributorObject New-AzImageBuilderTemplateSourceObject was prompting for PlatformImageSource and list of parameters changed. New-AzImageBuilderTemplateCustomizerObject with PowerShellCustomizer $true wasn't working, it kept prompting for the value when running the script. Appears to require to be passed without a value.

Not changed but something I decided to use:
Invoke-Expression ". \Get-AzureImageInfo.ps1" instead of . E1\Get-AzureImageInfo.ps1